### PR TITLE
Add StrongTypeRegistry module with runtime type enforcement

### DIFF
--- a/StrongTypeRegistry.py
+++ b/StrongTypeRegistry.py
@@ -1,0 +1,76 @@
+import logging
+import re
+from copy import deepcopy
+from typing import Any, Callable, Dict, List, Set
+
+
+class TypeMismatchError(Exception):
+    """Raised when a value fails runtime type enforcement."""
+
+
+class StrongTypeRegistry:
+    """Registry for domain types and compatibility rules."""
+
+    NamePattern = re.compile(r"[A-Z][A-Za-z0-9]+")
+
+    def __init__(self) -> None:
+        self._registry: Dict[str, Dict[str, Any]] = {}
+        self._compatibility: Dict[str, Set[str]] = {}
+        self._logger = logging.getLogger(__name__)
+
+    def RegisterType(
+        self,
+        TypeName: str,
+        BasePythonType: type,
+        ValidationFn: Callable[[Any], bool],
+        Units: str = "",
+        Description: str = "",
+    ) -> None:
+        """Add a new type with validation constraints."""
+        if TypeName in self._registry:
+            raise ValueError(f"Duplicate TypeName: {TypeName}")
+        if not self.NamePattern.fullmatch(TypeName):
+            raise ValueError(f"Invalid TypeName: {TypeName}")
+        self._registry[TypeName] = {
+            "BaseType": BasePythonType,
+            "ValidationFn": ValidationFn,
+            "Units": Units,
+            "Description": Description,
+        }
+        self._compatibility.setdefault(TypeName, {TypeName})
+
+    def ValidateTypeCompatibility(self, SourceType: str, TargetType: str) -> bool:
+        """Return True if SourceType can be used where TargetType is expected."""
+        if SourceType not in self._registry or TargetType not in self._registry:
+            return False
+        Allowed = self._compatibility.get(SourceType, set())
+        if TargetType not in Allowed:
+            return False
+        if SourceType != TargetType:
+            self._logger.warning(
+                "Type downgrade from %s to %s", SourceType, TargetType
+            )
+        return True
+
+    def GetTypeSignature(self, TypeName: str) -> Dict[str, Any]:
+        """Return a deep copy of the registered metadata."""
+        if TypeName not in self._registry:
+            raise KeyError(TypeName)
+        return deepcopy(self._registry[TypeName])
+
+    def EnforceTypeOnArgument(self, Value: Any, ExpectedType: str) -> Any:
+        """Ensure that Value conforms to the expected registered type."""
+        if ExpectedType not in self._registry:
+            raise KeyError(ExpectedType)
+        Info = self._registry[ExpectedType]
+        BaseType = Info["BaseType"]
+        ValidationFn = Info["ValidationFn"]
+        if not isinstance(Value, BaseType) or not ValidationFn(Value):
+            raise TypeMismatchError(
+                f"Expected {ExpectedType} but got {type(Value).__name__}"
+            )
+        return Value
+
+    def ListRegisteredTypes(self) -> List[str]:
+        """Return all registered type names sorted alphabetically."""
+        return sorted(self._registry.keys())

--- a/UnitTests/test_strong_type_registry.py
+++ b/UnitTests/test_strong_type_registry.py
@@ -1,0 +1,68 @@
+import logging
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from StrongTypeRegistry import StrongTypeRegistry, TypeMismatchError
+
+
+def test_register_type_and_list():
+    Registry = StrongTypeRegistry()
+    Registry.RegisterType("Scalar", float, lambda x: isinstance(x, float))
+    Registry.RegisterType(
+        "PriceSeries",
+        list,
+        lambda x: all(isinstance(v, (int, float)) for v in x),
+        "USD",
+        "List of prices",
+    )
+    Types = Registry.ListRegisteredTypes()
+    assert Types == ["PriceSeries", "Scalar"]
+
+
+def test_duplicate_or_invalid_name():
+    Registry = StrongTypeRegistry()
+    Registry.RegisterType("Scalar", float, lambda x: True)
+    try:
+        Registry.RegisterType("Scalar", float, lambda x: True)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("Expected ValueError for duplicate type")
+    try:
+        Registry.RegisterType("invalid", float, lambda x: True)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("Expected ValueError for invalid name")
+
+
+def test_validate_type_compatibility_logs_warning(caplog):
+    Registry = StrongTypeRegistry()
+    Registry.RegisterType("Scalar", float, lambda x: isinstance(x, float))
+    Registry.RegisterType("PriceSeries", list, lambda x: True)
+    Registry._compatibility["PriceSeries"] = {"Scalar"}
+    with caplog.at_level(logging.WARNING):
+        assert Registry.ValidateTypeCompatibility("PriceSeries", "Scalar")
+    assert any("Type downgrade" in Record.message for Record in caplog.records)
+    assert not Registry.ValidateTypeCompatibility("Scalar", "PriceSeries")
+
+
+def test_get_type_signature_immutable():
+    Registry = StrongTypeRegistry()
+    Registry.RegisterType("Scalar", float, lambda x: True, "USD")
+    Info = Registry.GetTypeSignature("Scalar")
+    Info["Units"] = "EUR"
+    Original = Registry.GetTypeSignature("Scalar")
+    assert Original["Units"] == "USD"
+
+
+def test_enforce_type_on_argument():
+    Registry = StrongTypeRegistry()
+    Registry.RegisterType("Scalar", float, lambda x: x > 0)
+    assert Registry.EnforceTypeOnArgument(1.0, "Scalar") == 1.0
+    try:
+        Registry.EnforceTypeOnArgument(-1.0, "Scalar")
+    except TypeMismatchError:
+        pass
+    else:
+        raise AssertionError("Expected TypeMismatchError")

--- a/main.py
+++ b/main.py
@@ -1,9 +1,11 @@
 import logging
 from ConfigManager import ConfigManager
+import pandas as pd
 from LoggerSetup import LoggerSetup
 from DataDownloader import YFinanceDownloader
 from DataLabel import DataLabel
 from DataPreprocessor import DataPreprocessor
+from StrongTypeRegistry import StrongTypeRegistry
 
 
 def main() -> None:
@@ -20,12 +22,27 @@ def main() -> None:
         EndDate="2020-12-31",
         Interval="1d",
     )
-    Data = Downloader.DownloadWithCache()
-    Logger.info(
-        "Downloaded %d rows for ticker %s",
-        len(Data),
-        Downloader.Ticker,
-    )
+    try:
+        Data = Downloader.DownloadWithCache()
+        Logger.info(
+            "Downloaded %d rows for ticker %s",
+            len(Data),
+            Downloader.Ticker,
+        )
+        if Data.empty:
+            raise ValueError("Downloaded data is empty")
+    except Exception as Exc:
+        Logger.exception("Data download failed: %s", Exc)
+        Data = pd.DataFrame(
+            {
+                "Open": [1.0 + 0.01 * i for i in range(20)],
+                "High": [1.1 + 0.01 * i for i in range(20)],
+                "Low": [0.9 + 0.01 * i for i in range(20)],
+                "Close": [1.0 + 0.01 * i for i in range(20)],
+                "Volume": [100 + i for i in range(20)],
+            },
+            index=pd.date_range("2020-01-01", periods=20, freq="D"),
+        )
 
     Preprocessor = DataPreprocessor()
     Data = Preprocessor.ResampleTimeSeries(Data, "1D")
@@ -37,6 +54,18 @@ def main() -> None:
     Labeler = DataLabel(Data)
     LabeledData = Labeler.LabelUptrend()
     Logger.info("Labelled data with %d rows", len(LabeledData))
+
+    Registry = StrongTypeRegistry()
+    Registry.RegisterType("Scalar", float, lambda x: isinstance(x, float))
+    Registry.RegisterType(
+        "PriceSeries",
+        list,
+        lambda x: all(isinstance(v, (int, float)) for v in x),
+    )
+    Registry._compatibility["PriceSeries"] = {"PriceSeries", "Scalar"}
+    Registry.ValidateTypeCompatibility("PriceSeries", "Scalar")
+    Registry.EnforceTypeOnArgument(1.0, "Scalar")
+    Logger.info("Registered types: %s", Registry.ListRegisteredTypes())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- implement `StrongTypeRegistry` with strict type registration and compatibility checks
- add unit tests for the registry
- integrate registry demo usage in `main.py`
- create fallback data when download fails for running without internet