### PR TITLE
Add IndicatorFactory with typed indicator support

### DIFF
--- a/IndicatorFactory.py
+++ b/IndicatorFactory.py
@@ -1,0 +1,95 @@
+import logging
+import inspect
+import time
+from typing import Any, Callable, Dict, List, Tuple
+
+from StrongTypeRegistry import StrongTypeRegistry, TypeMismatchError
+
+
+class UnknownIndicatorError(Exception):
+    """Raised when referencing an unregistered indicator."""
+
+
+class IndicatorFactory:
+    """Provide strongly typed technical indicator functions."""
+
+    PerformanceThreshold = 0.5  # seconds
+
+    def __init__(self, Registry: StrongTypeRegistry) -> None:
+        self._typeRegistry = Registry
+        self._registry: Dict[str, Dict[str, Any]] = {}
+        self._logger = logging.getLogger(__name__)
+
+    def RegisterIndicatorFunction(
+        self,
+        FuncName: str,
+        Implementation: Callable,
+        InputTypes: Tuple[str, ...],
+        OutputType: str,
+    ) -> None:
+        """Add a new indicator with its type signature."""
+        if FuncName in self._registry:
+            raise ValueError(f"Duplicate indicator: {FuncName}")
+
+        for TypeName in InputTypes + (OutputType,):
+            self._typeRegistry.GetTypeSignature(TypeName)
+
+        if len(inspect.signature(Implementation).parameters) != len(InputTypes):
+            raise ValueError("Implementation arity mismatch")
+
+        Cache: Dict[Tuple[Any, ...], Any] = {}
+
+        def _Wrapper(*Args: Any) -> Any:
+            Key = tuple(
+                tuple(Item) if isinstance(Item, list) else Item for Item in Args
+            )
+            if Key not in Cache:
+                Cache[Key] = Implementation(*Args)
+            return Cache[Key]
+
+        Cached = _Wrapper
+        self._registry[FuncName] = {
+            "Impl": Cached,
+            "Inputs": InputTypes,
+            "Output": OutputType,
+        }
+
+    def GetIndicatorSignature(self, FuncName: str) -> Tuple[Tuple[str, ...], str]:
+        """Return the type signature for the indicator."""
+        Info = self._registry.get(FuncName)
+        if Info is None:
+            raise UnknownIndicatorError(FuncName)
+        return Info["Inputs"], Info["Output"]
+
+    def ComputeIndicator(self, FuncName: str, Args: Tuple[Any, ...]) -> Any:
+        """Execute the indicator after enforcing types."""
+        Info = self._registry.get(FuncName)
+        if Info is None:
+            raise UnknownIndicatorError(FuncName)
+
+        if len(Args) != len(Info["Inputs"]):
+            raise ValueError("Incorrect number of arguments")
+
+        Validated: List[Any] = []
+        for Arg, Expected in zip(Args, Info["Inputs"]):
+            try:
+                Validated.append(
+                    self._typeRegistry.EnforceTypeOnArgument(Arg, Expected)
+                )
+            except (TypeMismatchError, KeyError) as Exc:
+                self._logger.error("Type enforcement failed for %s: %s", FuncName, Exc)
+                raise
+
+        Start = time.perf_counter()
+        Result = Info["Impl"](*Validated)
+        Duration = time.perf_counter() - Start
+        if Duration > self.PerformanceThreshold:
+            self._logger.warning("%s execution took %.3f seconds", FuncName, Duration)
+
+        self._typeRegistry.EnforceTypeOnArgument(Result, Info["Output"])
+        return Result
+
+    def ListAvailableIndicators(self) -> List[str]:
+        """Return a list of registered indicator names."""
+        return sorted(self._registry.keys())
+

--- a/UnitTests/test_indicator_factory.py
+++ b/UnitTests/test_indicator_factory.py
@@ -1,0 +1,85 @@
+import logging
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from IndicatorFactory import IndicatorFactory, UnknownIndicatorError
+from StrongTypeRegistry import StrongTypeRegistry, TypeMismatchError
+
+
+def _Sma(Series: list[float], Length: int) -> float:
+    return sum(Series[-Length:]) / Length
+
+
+def _Slow(Series: list[float], Length: int) -> float:
+    time.sleep(0.01)
+    return _Sma(Series, Length)
+
+
+def _SetupRegistry() -> StrongTypeRegistry:
+    Registry = StrongTypeRegistry()
+    Registry.RegisterType("PriceSeries", list, lambda x: all(isinstance(v, (int, float)) for v in x))
+    Registry.RegisterType("WindowLength", int, lambda x: isinstance(x, int) and x > 0)
+    Registry.RegisterType("Scalar", float, lambda x: isinstance(x, float))
+    return Registry
+
+
+def test_register_and_list():
+    Registry = _SetupRegistry()
+    Factory = IndicatorFactory(Registry)
+    Factory.RegisterIndicatorFunction(
+        "SMA", _Sma, ("PriceSeries", "WindowLength"), "Scalar"
+    )
+    assert Factory.ListAvailableIndicators() == ["SMA"]
+    Inputs, Output = Factory.GetIndicatorSignature("SMA")
+    assert Inputs == ("PriceSeries", "WindowLength")
+    assert Output == "Scalar"
+
+
+def test_compute_indicator_success():
+    Registry = _SetupRegistry()
+    Factory = IndicatorFactory(Registry)
+    Factory.RegisterIndicatorFunction(
+        "SMA", _Sma, ("PriceSeries", "WindowLength"), "Scalar"
+    )
+    Result = Factory.ComputeIndicator("SMA", ([1.0, 2.0, 3.0], 3))
+    assert isinstance(Result, float)
+
+
+def test_compute_indicator_type_mismatch():
+    Registry = _SetupRegistry()
+    Factory = IndicatorFactory(Registry)
+    Factory.RegisterIndicatorFunction(
+        "SMA", _Sma, ("PriceSeries", "WindowLength"), "Scalar"
+    )
+    try:
+        Factory.ComputeIndicator("SMA", (123, 1))
+    except TypeMismatchError:
+        pass
+    else:
+        raise AssertionError("Expected TypeMismatchError")
+
+
+def test_unknown_indicator():
+    Registry = _SetupRegistry()
+    Factory = IndicatorFactory(Registry)
+    try:
+        Factory.GetIndicatorSignature("MISSING")
+    except UnknownIndicatorError:
+        pass
+    else:
+        raise AssertionError("Expected UnknownIndicatorError")
+
+
+def test_execution_warning(caplog):
+    Registry = _SetupRegistry()
+    Factory = IndicatorFactory(Registry)
+    Factory.RegisterIndicatorFunction(
+        "SLOW", _Slow, ("PriceSeries", "WindowLength"), "Scalar"
+    )
+    Factory.PerformanceThreshold = 0.0
+    with caplog.at_level(logging.WARNING):
+        Factory.ComputeIndicator("SLOW", ([1.0, 2.0, 3.0], 1))
+    assert any("SLOW" in Record.message for Record in caplog.records)

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from DataDownloader import YFinanceDownloader
 from DataLabel import DataLabel
 from DataPreprocessor import DataPreprocessor
 from StrongTypeRegistry import StrongTypeRegistry
+from IndicatorFactory import IndicatorFactory
 
 
 def main() -> None:
@@ -62,10 +63,27 @@ def main() -> None:
         list,
         lambda x: all(isinstance(v, (int, float)) for v in x),
     )
+    Registry.RegisterType(
+        "WindowLength", int, lambda x: isinstance(x, int) and x > 0
+    )
     Registry._compatibility["PriceSeries"] = {"PriceSeries", "Scalar"}
     Registry.ValidateTypeCompatibility("PriceSeries", "Scalar")
     Registry.EnforceTypeOnArgument(1.0, "Scalar")
     Logger.info("Registered types: %s", Registry.ListRegisteredTypes())
+
+    Factory = IndicatorFactory(Registry)
+
+    def _SimpleMovingAverage(Series: list[float], Length: int) -> float:
+        return sum(Series[-Length:]) / Length
+
+    Factory.RegisterIndicatorFunction(
+        "SMA",
+        _SimpleMovingAverage,
+        ("PriceSeries", "WindowLength"),
+        "Scalar",
+    )
+    Example = Factory.ComputeIndicator("SMA", ([1.0, 2.0, 3.0, 4.0], 2))
+    Logger.info("Example SMA calculation: %.2f", Example)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- implement `IndicatorFactory` to manage typed indicator functions
- add unit tests for `IndicatorFactory`
- update `main.py` to demonstrate new indicator factory usage