### PR TITLE
Add PriceToIndicator primitive

### DIFF
--- a/GPPrimitives.py
+++ b/GPPrimitives.py
@@ -154,6 +154,11 @@ class GPPrimitives:
         Result = self.IndicatorLib.SMA(Price.Values, Length.Value)
         return IndicatorSeries(Result)
 
+    @staticmethod
+    def PriceToIndicator(Price: PriceSeries) -> IndicatorSeries:
+        """Convert ``PriceSeries`` to ``IndicatorSeries`` without modification."""
+        return IndicatorSeries(Price.Values)
+
     def _RegisterOperators(self) -> None:
         P = self.PrimitiveSet
         # Addition
@@ -184,6 +189,7 @@ class GPPrimitives:
         P = self.PrimitiveSet
         P.addPrimitive(self._WrapEma, [PriceSeries, WindowLength], IndicatorSeries, name="EMA")
         P.addPrimitive(self._WrapSma, [PriceSeries, WindowLength], IndicatorSeries, name="SMA")
+        P.addPrimitive(self.PriceToIndicator, [PriceSeries], IndicatorSeries, name="PriceToIndicator")
 
     def _RegisterTerminals(self) -> None:
         self.PrimitiveSet.addEphemeralConstant(

--- a/UnitTests/GPPrimitivesCompileTests.py
+++ b/UnitTests/GPPrimitivesCompileTests.py
@@ -20,3 +20,16 @@ def test_compile_indicator_terminal() -> None:
     evaluator = EvaluateFitness(Data, Prims)
     fitness = evaluator.ComputeFitness(tree)
     assert 0.0 <= fitness <= 1.0
+
+
+def test_compile_price_to_indicator() -> None:
+    Data = pd.DataFrame({"Close": [1, 2, 3], "Label": [0, 1, 0]})
+    Prims = GPPrimitives()
+    tree = gp.PrimitiveTree.from_string(
+        "PriceToIndicator(ClosePrice)", pset=Prims.PrimitiveSet
+    )
+    func = gp.compile(expr=tree, pset=Prims.PrimitiveSet)
+    assert func is not None
+    evaluator = EvaluateFitness(Data, Prims)
+    fitness = evaluator.ComputeFitness(tree)
+    assert 0.0 <= fitness <= 1.0

--- a/UnitTests/GPPrimitivesTests.py
+++ b/UnitTests/GPPrimitivesTests.py
@@ -4,7 +4,13 @@ import pandas as pd
 
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from GPPrimitives import GPPrimitives, IndicatorSeries, Scalar, WindowLength
+from GPPrimitives import (
+    GPPrimitives,
+    IndicatorSeries,
+    PriceSeries,
+    Scalar,
+    WindowLength,
+)
 
 
 def test_add_series_and_scalar() -> None:
@@ -25,6 +31,22 @@ def test_primitive_set_contains_ema() -> None:
         Prim.name == "EMA" for Prim in Prims.PrimitiveSet.primitives[IndicatorSeries]
     )
     assert HasEma
+
+
+def test_price_to_indicator() -> None:
+    Prices = pd.Series([10, 20, 30])
+    Series = PriceSeries(Prices)
+    Prims = GPPrimitives()
+    Result = Prims.PriceToIndicator(Series)
+    pd.testing.assert_series_equal(Result.Values, Prices)
+
+
+def test_primitive_set_contains_price_to_indicator() -> None:
+    Prims = GPPrimitives()
+    HasPrim = any(
+        Prim.name == "PriceToIndicator" for Prim in Prims.PrimitiveSet.primitives[IndicatorSeries]
+    )
+    assert HasPrim
 
 
 def test_rand_window_ephemeral_range() -> None:

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ from DataDownloader import DataDownloader
 from LogManager import LogManager
 from ConfigManager import ConfigManager
 from Indicator import Indicator
-from GPPrimitives import GPPrimitives, WindowLength
+from GPPrimitives import GPPrimitives, WindowLength, PriceSeries
 from GPPopulation import GPPopulation
 from DataLabel import DataLabel
 import logging
@@ -31,6 +31,11 @@ def Main() -> None:
         Params["Interval"],
     )
     Data = Labeler.AddLabel(Data)
+    PriceSeriesObj = PriceSeries(Data["Close"])
+    PriceIndicator = Primitives.PriceToIndicator(PriceSeriesObj)
+    logging.getLogger(__name__).info(
+        "PriceToIndicator sample: %s", PriceIndicator.Values.head().tolist()
+    )
     # Build primitive set to ensure all primitives are registered
     Pset = Primitives.GetPrimitiveSet()
     SampleWindow = Pset.terminals[WindowLength][0]().value.Value


### PR DESCRIPTION
## Summary
- implement PriceToIndicator primitive in `GPPrimitives`
- register new primitive for use in GP
- add unit tests for conversion and compilation
- log sample conversion in main